### PR TITLE
Changing rain from integer to float

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1453,18 +1453,18 @@
                     "description": "Last Sea level pressure measured @ time_utc (in mb)"
                 },
                 "Rain": {
-                    "type": "integer",
-                    "format": "int32",
+                    "type": "number",
+                    "format": "float",
                     "description": "Last rain measured (in mm)"
                 },
                 "sum_rain_1": {
-                    "type": "integer",
-                    "format": "int32",
+                    "type": "number",
+                    "format": "float",
                     "description": "Amount of rain in last hour"
                 },
                 "sum_rain_24": {
-                    "type": "integer",
-                    "format": "int32",
+                    "type": "number",
+                    "format": "float",
                     "description": "Amount of rain today"
                 },
                 "WindAngle": {

--- a/swagger_access_token.json
+++ b/swagger_access_token.json
@@ -1541,18 +1541,18 @@
                     "description": "Last Sea level pressure measured @ time_utc (in mb)"
                 },
                 "Rain": {
-                    "type": "integer",
-                    "format": "int32",
+                    "type": "number",
+                    "format": "float",
                     "description": "Last rain measured (in mm)"
                 },
                 "sum_rain_1": {
-                    "type": "integer",
-                    "format": "int32",
+                    "type": "number",
+                    "format": "float",
                     "description": "Amount of rain in last hour"
                 },
                 "sum_rain_24": {
-                    "type": "integer",
-                    "format": "int32",
+                    "type": "number",
+                    "format": "float",
                     "description": "Amount of rain today"
                 },
                 "WindAngle": {


### PR DESCRIPTION
Hello @cbornet, 

While using the swagger lib, it seems that many users face a problem with rain being described as an integer. While in Netatmo doc there are not so much informations, in their example (https://dev.netatmo.com/doc/methods/getstationsdata) it seems that it's a float value.

Regards

Signed-off-by: Gaël L'hopital <glhopital@gmail.com>