### PR TITLE
Presence API event extension

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 1.1.3
+  version: 1.1.4
   title: Netatmo
   description: |
     <h3>Welcome to the Netatmo swagger on-line documentation !</h3>
@@ -2183,6 +2183,35 @@ definitions:
         type: integer
         format: int32
         description: Subtypes of SD and Alim events. Go to Welcome page for further details.
+      event_list:
+        type: array
+        items:
+          $ref: '#/definitions/NAWelcomeSubEvent'
+  NAWelcomeSubEvent:
+    properties:
+      id:
+        type: string
+        description: Identifier of the sub event
+      type:
+        type: string
+        enum:
+          - human
+          - animal
+          - vehicle
+        description: Type of the detected object.
+      time:
+        type: integer
+        format: int32
+        description: Time of occurence of the sub event
+      offset:
+        type: integer
+        format: int32
+      message:
+        type: string
+        description: User facing sub event description
+      snapshot:
+        $ref: '#/definitions/NAWelcomeSnapshot'
+        description: 'Snapshot id, version and key. (Used in Getcamerapicture)'
   NAWelcomeSnapshot:
     properties:
       id:


### PR DESCRIPTION
The Presence (outdoor) camera uses sub events. These are available via .../events/[i]/event_list/...

See issue #25