### PR TITLE
Bug-fixes regarding recent pull-requests

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -135,6 +135,8 @@ paths:
           in: query
           description: 'When set to "true", the favorite devices of the user are returned. This flag is available only if the devices requested are Weather Stations.'
           type: boolean
+          required: false
+          default: false
       responses:
         '200':
           description: Successful response
@@ -349,6 +351,7 @@ paths:
           in: query
           description: Whether to include the user's favorite Weather Stations in addition to the user's own Weather Stations
           type: boolean
+          default: false
       responses:
         '200':
           description: Successful response
@@ -2165,9 +2168,9 @@ definitions:
       light_mode_status:
         type: string
         enum:
-          - on
-          - off
-          - auto
+          - "on"
+          - "off"
+          - "auto"
         description: State of (flood-)light
   NAWelcomeEvent:
     properties:


### PR DESCRIPTION
- enum values with the name of "on" and "off" have to be written within quotes, otherwise this is equal to "true" and "false" which causes the the swagger-codegen doesn't generate enum elements for "on" and "off". See https://github.com/swagger-api/swagger-codegen/issues/2559
- the recently introduced parameter "get_favorites" is optional within the Netatmo API and has "false" as the default value. This way the change is downward compatible.