### PR TITLE
Fix plug_connected_boiler type

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 1.1.5
+  version: 1.1.6
   title: Netatmo
   description: |
     <h3>Welcome to the Netatmo swagger on-line documentation !</h3>
@@ -1624,8 +1624,7 @@ definitions:
           RSSI_THRESHOLD_1 = 71 middle quality signal
           RSSI_THRESHOLD_2 = 56 good signal
       plug_connected_boiler:
-        type: integer
-        format: int32
+        type: boolean
       udp_conn:
         type: boolean
       last_plug_seen:


### PR DESCRIPTION
As observed in openhab/openhab-addons#9875, a recent (server-side?) change has seen the `NAPlug.plug_connected_boiler` type change from integer to boolean, resulting in various breakages among clients generated from this spec.

The changes in this PR seem to fix that.
A couple of notes:

 - I bumped the version number, although I don't know if there's a rationale behind it and am willing to revert it in case it's not needed;
 - the `NAThermStateBody` object has a `plug_connected_boiler` field too, but given that it's used in the deprecated API call `/getthermstate` it has not been tested if it needs a type change too.